### PR TITLE
Stop using OrderedDict in ticket review output

### DIFF
--- a/src/ticket_review.py
+++ b/src/ticket_review.py
@@ -76,13 +76,11 @@ def _format_conversations(
     formatted: List[Dict[str, Any]] = []
     for row in conversation_rows:
         formatted.append(
-            OrderedDict(
-                [
-                    ("Speaker", row.get("speaker", "")),
-                    ("Message", row.get("message", "")),
-                    ("Timestamp", _format_timestamp(row.get("timestamp"))),
-                ]
-            )
+            {
+                "Speaker": row.get("speaker", ""),
+                "Message": row.get("message", ""),
+                "Timestamp": _format_timestamp(row.get("timestamp")),
+            }
         )
     return formatted
 
@@ -104,17 +102,15 @@ def _format_time_entries(
             duration_display = duration
 
         formatted.append(
-            OrderedDict(
-                [
-                    ("Tech", row.get("Tech", "")),
-                    ("Duration", duration_display),
-                    ("Visibility", row.get("Visibility", "")),
-                    ("Billable Status", row.get("Billable Status", "")),
-                    ("Labor Type", row.get("Labor Type", "")),
-                    ("Created At", _format_timestamp(row.get("Created At"))),
-                    ("Notes", row.get("Notes", "")),
-                ]
-            )
+            {
+                "Tech": row.get("Tech", ""),
+                "Duration": duration_display,
+                "Visibility": row.get("Visibility", ""),
+                "Billable Status": row.get("Billable Status", ""),
+                "Labor Type": row.get("Labor Type", ""),
+                "Created At": _format_timestamp(row.get("Created At")),
+                "Notes": row.get("Notes", ""),
+            }
         )
     return formatted
 


### PR DESCRIPTION
## Summary
- change the ticket review formatter to emit plain dictionaries for conversations and time entries
- ensure the preview structure no longer displays OrderedDict wrappers when printed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f4fba8b48321a8503cf27c3921e6)