### PR TITLE
Expose time entries in API response

### DIFF
--- a/api_interface.py
+++ b/api_interface.py
@@ -1,8 +1,9 @@
 from src.generate_ticket_data import generate_ticket
 from src.conversations import create_complete_ticket_conversation
+from src.time_entries import generate_time_entries
 
 def generate_single_ticket():
-    """Generate a single ticket with a conversation."""
+    """Generate a single ticket with conversation and time entry data."""
     ticket = generate_ticket()
     if ticket is None:
         return None, "Failed to generate ticket"
@@ -11,4 +12,10 @@ def generate_single_ticket():
     if not conversation:
         return None, "Failed to generate conversation"
 
-    return {"ticket": ticket, "conversation": conversation}, None
+    time_entries = generate_time_entries(ticket) or []
+
+    return {
+        "ticket": ticket,
+        "conversation": conversation,
+        "time_entries": time_entries,
+    }, None


### PR DESCRIPTION
## Summary
- include time entry generation when producing a ticket via the API interface
- return an empty list when no time entries are generated so callers have a stable structure

## Testing
- python -m compileall .

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910f7fcada48321b5bc4dd9daf1b8db)