### PR TITLE
Update Syncro CSV output to separate tech and end user columns

### DIFF
--- a/generate_syncro_data.py
+++ b/generate_syncro_data.py
@@ -15,7 +15,8 @@ except Exception:  # pragma: no cover - fallback for standalone execution
 HEADERS = [
     "ticket customer",
     "ticket number",
-    "user",
+    "Tech",
+    "End User",
     "ticket subject",
     "ticket description",
     "ticket response",
@@ -86,9 +87,13 @@ def build_output_row(
     return {
         "ticket customer": ticket_customer,
         "ticket number": ticket_number,
-        "user": select_first(
+        "Tech": select_first(
+            ticket_row.get("Assigned Tech") if ticket_row else None,
             conversation_row.get("speaker") if conversation_row else None,
+        ),
+        "End User": select_first(
             ticket_row.get("Contact") if ticket_row else None,
+            conversation_row.get("speaker") if conversation_row else None,
         ),
         "ticket subject": select_first(ticket_row.get("Subject") if ticket_row else None),
         "ticket description": select_first(ticket_row.get("Description") if ticket_row else None),


### PR DESCRIPTION
## Summary
- replace the Syncro CSV `user` column with `Tech` and `End User`
- populate the new columns using the assigned technician and ticket contact data

## Testing
- python -m compileall generate_syncro_data.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114799ccd883219c2cc0b0d43f46ad)