### PR TITLE
Rename Syncro data generator to CSV variant

### DIFF
--- a/generate_syncro_csv.py
+++ b/generate_syncro_csv.py
@@ -87,11 +87,11 @@ def build_output_row(
     return {
         "ticket customer": ticket_customer,
         "ticket number": ticket_number,
-        "Tech": select_first(
+        "tech": select_first(
             ticket_row.get("Assigned Tech") if ticket_row else None,
             conversation_row.get("speaker") if conversation_row else None,
         ),
-        "End User": select_first(
+        "end user": select_first(
             ticket_row.get("Contact") if ticket_row else None,
             conversation_row.get("speaker") if conversation_row else None,
         ),


### PR DESCRIPTION
## Summary
- rename the Syncro data export utility to `generate_syncro_csv.py`
- align generated row keys with the declared CSV header names

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69114b4dea1c8321bca6715b569da815)